### PR TITLE
feat: use FluentResults for product repository

### DIFF
--- a/src/Services/Catalog/Catalog.API/Catalog.API.csproj
+++ b/src/Services/Catalog/Catalog.API/Catalog.API.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -10,11 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentResults" Version="3.14.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.19.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
-  <ProjectExtensions><VisualStudio><UserProperties appsettings_1json__JsonSchema="" /></VisualStudio></ProjectExtensions>
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties appsettings_1json__JsonSchema="" />
+    </VisualStudio>
+  </ProjectExtensions>
 
 </Project>
+

--- a/src/Services/Catalog/Catalog.API/Controllers/CatalogController.cs
+++ b/src/Services/Catalog/Catalog.API/Controllers/CatalogController.cs
@@ -1,5 +1,6 @@
-﻿using Catalog.API.Entities;
+using Catalog.API.Entities;
 using Catalog.API.Repositories;
+using FluentResults;
 using Microsoft.AspNetCore.Mvc;
 using System.Net;
 
@@ -22,8 +23,12 @@ namespace Catalog.API.Controllers
         [ProducesResponseType(typeof(IEnumerable<Product>), (int)HttpStatusCode.OK)]
         public async Task<ActionResult<IEnumerable<Product>>> GetProducts()
         {
-            var products = await _repository.GetProducts();
-            return Ok(products);
+            var result = await _repository.GetProducts();
+            if (result.IsFailed)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, result.Errors);
+            }
+            return Ok(result.Value);
         }
 
         [HttpGet("{id:length(24)}", Name = "GetProduct")]
@@ -31,13 +36,13 @@ namespace Catalog.API.Controllers
         [ProducesResponseType(typeof(Product), (int)HttpStatusCode.OK)]
         public async Task<ActionResult<Product>> GetProductById(string id)
         {
-            var product = await _repository.GetProduct(id);
-            if (product == null)
+            var result = await _repository.GetProduct(id);
+            if (result.IsFailed)
             {
                 _logger.LogError($"Product with id: {id}, not found.");
-                return NotFound();
+                return NotFound(result.Errors);
             }
-            return Ok(product);
+            return Ok(result.Value);
         }
 
         [Route("[action]/{category}", Name = "GetProductByCategory")]
@@ -45,31 +50,53 @@ namespace Catalog.API.Controllers
         [ProducesResponseType(typeof(IEnumerable<Product>), (int)HttpStatusCode.OK)]
         public async Task<ActionResult<IEnumerable<Product>>> GetProductByCategory(string category)
         {
-            var products = await _repository.GetProductByCategory(category);
-            return Ok(products);
+            var result = await _repository.GetProductByCategory(category);
+            if (result.IsFailed)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, result.Errors);
+            }
+            return Ok(result.Value);
         }
 
         [HttpPost]
         [ProducesResponseType(typeof(Product), (int)HttpStatusCode.OK)]
         public async Task<ActionResult<Product>> CreateProduct([FromBody] Product product)
         {
-            await _repository.CreateProduct(product);
+            var result = await _repository.CreateProduct(product);
 
-            return CreatedAtRoute("GetProduct", new { id = product.Id }, product);
+            if (result.IsFailed)
+            {
+                return StatusCode((int)HttpStatusCode.InternalServerError, result.Errors);
+            }
+
+            return CreatedAtRoute("GetProduct", new { id = result.Value.Id }, result.Value);
         }
 
         [HttpPut]
-        [ProducesResponseType(typeof(Product), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(bool), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> UpdateProduct([FromBody] Product product)
         {
-            return Ok(await _repository.UpdateProduct(product));
+            var result = await _repository.UpdateProduct(product);
+            if (result.IsFailed)
+            {
+                return NotFound(result.Errors);
+            }
+
+            return Ok(result.Value);
         }
 
         [HttpDelete("{id:length(24)}", Name = "DeleteProduct")]
-        [ProducesResponseType(typeof(Product), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(bool), (int)HttpStatusCode.OK)]
         public async Task<IActionResult> DeleteProductById(string id)
         {
-            return Ok(await _repository.DeleteProduct(id));
+            var result = await _repository.DeleteProduct(id);
+            if (result.IsFailed)
+            {
+                return NotFound(result.Errors);
+            }
+
+            return Ok(result.Value);
         }
     }
 }
+

--- a/src/Services/Catalog/Catalog.API/Repositories/IProductRepository.cs
+++ b/src/Services/Catalog/Catalog.API/Repositories/IProductRepository.cs
@@ -1,16 +1,18 @@
-﻿using Catalog.API.Entities;
+using Catalog.API.Entities;
+using FluentResults;
 
 namespace Catalog.API.Repositories
 {
     public interface IProductRepository
     {
-        Task<IEnumerable<Product>> GetProducts();
-        Task<Product> GetProduct(string id);
-        Task<IEnumerable<Product>> GetProductByName(string name);
-        Task<IEnumerable<Product>> GetProductByCategory(string categoryName);
+        Task<Result<IEnumerable<Product>>> GetProducts();
+        Task<Result<Product>> GetProduct(string id);
+        Task<Result<IEnumerable<Product>>> GetProductByName(string name);
+        Task<Result<IEnumerable<Product>>> GetProductByCategory(string categoryName);
 
-        Task CreateProduct(Product product);
-        Task<bool> UpdateProduct(Product product);
-        Task<bool> DeleteProduct(string id);
+        Task<Result<Product>> CreateProduct(Product product);
+        Task<Result<bool>> UpdateProduct(Product product);
+        Task<Result<bool>> DeleteProduct(string id);
     }
 }
+

--- a/src/Services/Catalog/Catalog.API/Repositories/ProductRepository.cs
+++ b/src/Services/Catalog/Catalog.API/Repositories/ProductRepository.cs
@@ -1,5 +1,6 @@
-﻿using Catalog.API.Data;
+using Catalog.API.Data;
 using Catalog.API.Entities;
+using FluentResults;
 using MongoDB.Driver;
 
 namespace Catalog.API.Repositories
@@ -13,65 +14,139 @@ namespace Catalog.API.Repositories
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public async Task<IEnumerable<Product>> GetProducts()
+        public async Task<Result<IEnumerable<Product>>> GetProducts()
         {
-            return await _context
-                            .Products
-                            .Find(p => true)
-                            .ToListAsync();
-        }
-        public async Task<Product> GetProduct(string id)
-        {
-            return await _context
-                           .Products
-                           .Find(p => p.Id == id)
-                           .FirstOrDefaultAsync();
-        }
-
-        public async Task<IEnumerable<Product>> GetProductByName(string name)
-        {
-            FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Name, name);
-
-            return await _context
-                            .Products
-                            .Find(filter)
-                            .ToListAsync();
+            try
+            {
+                var products = await _context.Products.Find(p => true).ToListAsync();
+                return Result.Ok(products);
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
         }
 
-        public async Task<IEnumerable<Product>> GetProductByCategory(string categoryName)
+        public async Task<Result<Product>> GetProduct(string id)
         {
-            FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Category, categoryName);
-
-            return await _context
-                            .Products
-                            .Find(filter)
-                            .ToListAsync();
+            try
+            {
+                var product = await _context.Products.Find(p => p.Id == id).FirstOrDefaultAsync();
+                if (product == null)
+                {
+                    return Result.Fail($"Product with id: {id}, not found.");
+                }
+                return Result.Ok(product);
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
         }
 
-        public async Task CreateProduct(Product product)
+        public async Task<Result<IEnumerable<Product>>> GetProductByName(string name)
         {
-            await _context.Products.InsertOneAsync(product);
+            try
+            {
+                FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Name, name);
+                var products = await _context.Products.Find(filter).ToListAsync();
+                return Result.Ok(products);
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
         }
 
-        public async Task<bool> UpdateProduct(Product product)
+        public async Task<Result<IEnumerable<Product>>> GetProductByCategory(string categoryName)
         {
-            var updateResult = await _context
-                                        .Products
-                                        .ReplaceOneAsync(filter: g => g.Id == product.Id, replacement: product);
-
-            return updateResult.IsAcknowledged && updateResult.ModifiedCount > 0;
+            try
+            {
+                FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Category, categoryName);
+                var products = await _context.Products.Find(filter).ToListAsync();
+                return Result.Ok(products);
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
         }
 
-        public async Task<bool> DeleteProduct(string id)
+        public async Task<Result<Product>> CreateProduct(Product product)
         {
-            FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Id, id);
-
-            DeleteResult deleteResult = await _context
-                                                .Products
-                                                .DeleteOneAsync(filter);
-
-            return deleteResult.IsAcknowledged && deleteResult.DeletedCount > 0;
+            try
+            {
+                await _context.Products.InsertOneAsync(product);
+                return Result.Ok(product);
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
         }
 
+        public async Task<Result<bool>> UpdateProduct(Product product)
+        {
+            try
+            {
+                var updateResult = await _context.Products.ReplaceOneAsync(g => g.Id == product.Id, product);
+                if (updateResult.IsAcknowledged && updateResult.ModifiedCount > 0)
+                {
+                    return Result.Ok(true);
+                }
+                return Result.Fail("Product update failed");
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+        }
+
+        public async Task<Result<bool>> DeleteProduct(string id)
+        {
+            try
+            {
+                FilterDefinition<Product> filter = Builders<Product>.Filter.Eq(p => p.Id, id);
+                DeleteResult deleteResult = await _context.Products.DeleteOneAsync(filter);
+                if (deleteResult.IsAcknowledged && deleteResult.DeletedCount > 0)
+                {
+                    return Result.Ok(true);
+                }
+                return Result.Fail("Product delete failed");
+            }
+            catch (MongoException ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail(ex.Message);
+            }
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- add FluentResults package to Catalog API
- wrap product repository operations with Result types and error handling
- adjust controller for Result-based repository API

## Testing
- `dotnet build src/Services/Catalog/Catalog.API/Catalog.API.csproj` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6898ca2eefd88327a361ee52ce4676cf